### PR TITLE
Added circuit board UML diagram

### DIFF
--- a/content/en/References/_index.adoc
+++ b/content/en/References/_index.adoc
@@ -11,7 +11,4 @@ description: >
 * https://docs.google.com/document/d/164DD9j-OUmsBKB3FELcanB-5L1GkFy0qX10EiUfEtjM/edit[Testing Questions]
 * https://docs.google.com/spreadsheets/d/1FWTYRxglWDqIK_xI6HlBGKUegICQRsXe5NHCJTlTlHs/edit?usp=sharing[Printing Queue]
 * https://docs.google.com/presentation/d/1UeSRyUB0dAOZZecX4TGh40GkVtGADlXzBOwVFjPqIFE/edit#slide=id.g7f621674bc_0_63[System Concept Diagram]
-<<<<<<< HEAD
 * link:circuit_schematic.adoc[Circuit Schematic UML Diagram]
-=======
->>>>>>> parent of 9f17c3a... link to circuit uml diagram added to content\en\References\_index.adoc

--- a/content/en/References/_index.adoc
+++ b/content/en/References/_index.adoc
@@ -11,3 +11,7 @@ description: >
 * https://docs.google.com/document/d/164DD9j-OUmsBKB3FELcanB-5L1GkFy0qX10EiUfEtjM/edit[Testing Questions]
 * https://docs.google.com/spreadsheets/d/1FWTYRxglWDqIK_xI6HlBGKUegICQRsXe5NHCJTlTlHs/edit?usp=sharing[Printing Queue]
 * https://docs.google.com/presentation/d/1UeSRyUB0dAOZZecX4TGh40GkVtGADlXzBOwVFjPqIFE/edit#slide=id.g7f621674bc_0_63[System Concept Diagram]
+<<<<<<< HEAD
+* link:circuit_schematic.adoc[Circuit Schematic UML Diagram]
+=======
+>>>>>>> parent of 9f17c3a... link to circuit uml diagram added to content\en\References\_index.adoc

--- a/content/en/References/circuit_schematic.adoc
+++ b/content/en/References/circuit_schematic.adoc
@@ -8,9 +8,5 @@ description: >
 
 [plantuml, circuit_schematic, svg]
 ....
-<<<<<<< HEAD
-include::content/en/References/circuit_schematic.plantuml
-=======
 include::content/en/References/circuit_schematic.plantuml[]
->>>>>>> 13f4f3f... link to circuit uml diagram added to content\en\References\_index.adoc
 ....

--- a/content/en/References/circuit_schematic.adoc
+++ b/content/en/References/circuit_schematic.adoc
@@ -1,0 +1,16 @@
+---
+title: "Electronic sensing system"
+linkTitle: "Electronic sensing system"
+weight: 1
+description: >
+  Circuit schematic for electronic sensing system
+---
+
+[plantuml, circuit_schematic, svg]
+....
+<<<<<<< HEAD
+include::content/en/References/circuit_schematic.plantuml
+=======
+include::content/en/References/circuit_schematic.plantuml[]
+>>>>>>> 13f4f3f... link to circuit uml diagram added to content\en\References\_index.adoc
+....

--- a/content/en/References/circuit_schematic.plantuml
+++ b/content/en/References/circuit_schematic.plantuml
@@ -1,0 +1,73 @@
+@startuml
+left to right direction
+skinparam nodesep 100
+skinparam ranksep 100
+frame "ibd [System] Electronic Sensing System [Power and Data Flow]" {
+  [Raspberry Pi B+] <<Microcontroller>> as [Pi]
+  () "Wall Outlet" as WO
+  
+  rectangle "Power System" {
+    [LM259SX-5] <<Voltage Regulator>> as [VR]
+    [Power Jack] as PJ
+    WO ..> PJ
+    PJ ..> VR
+    VR ..> Pi: 5V
+  }
+
+  together {
+    rectangle "Pressure Sensing System" as PresSens{
+      [SPL06 - 007 (x5)] <<Pressure Sensors>> as Pres
+      [TCA9548A] <<I2C Pressure Multiplexer>> as [MUX1]
+      Pres .. MUX1: <<I2C>>
+    }
+
+    rectangle "Open-Source Flow Sensing System"  as Open{
+      [Automotive Airflow Sensors (x4)] <<Generic Sensors>> as AAS
+      [TCA9548A] <<Analog Digital Converter>> as [ADC]
+      () "Automotive Airflow Connectors (x4)" as ACon
+      AAS -- ACon
+      ACon .. ADC: <<SPI>>
+    }
+
+    rectangle "FDA-Approved Flow Sensing System"  as FDA{
+      [Sensirion Airflow Sensors (x4)] <<Sensirion Sensors>> as Sens
+      [TCA9548A] <<I2C Flow Multiplexer>> as [MUX2]
+      () "Sensirion Airflow Connectors (x4)" as SCon
+      Sens -- SCon
+      SCon .. MUX2: <<I2C>>
+    }
+  }
+
+  'Used for aligning boxes'
+  /'
+  PresSens -[hidden]-> FDA
+  FDA --> Open
+  '/
+
+  "Clinician" <<Human>> as Doc
+  "Patient" <<Human>> as Pat
+
+  Pat ..> Sens
+  Pat ..> Pres
+  Pat ..> AAS
+
+
+  MUX2 ..> Pi
+  ADC  ..> Pi
+  MUX1 ..> Pi
+
+  rectangle "Clinical Feedback" {
+      () "Raspberry Pi B+ Display" <<Display>> as Display
+      () "Indicator LEDs (x8)" as LED
+      () "Audio Alarm"  as Aud
+  }
+
+  Pi ..> LED
+  Pi ..> Aud
+  Pi ..> Display
+
+  LED ..> Doc
+  Aud ..> Doc
+  Display ..> Doc
+}
+@enduml


### PR DESCRIPTION
Link to circuit UML diagram added to content\en\References\_index.adoc, hosted on Google Drive. Corresponding .plantuml file added to directory for future use.