### PR TITLE
Closes #3, closes #24; revise configuration management page

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -116,7 +116,7 @@ url_latest_version = "https://example.com"
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
 github_repo = "https://github.com/tetrabiodistributed/project-tetra-docs"
 # An optional link to a related project repo. For example, the sibling repository where your product code lives.
-github_project_repo = "https://github.com/google/docsy"
+github_project_repo = "https://github.com/tetrabiodistributed/project-tetra"
 
 # Specify a value here if your content directory is not in your repo's root directory
 # github_subdir = ""

--- a/content/en/how-to-guides/_index.adoc
+++ b/content/en/how-to-guides/_index.adoc
@@ -2,8 +2,7 @@
 ---
 title: "How-To Guides"
 linkTitle: "How-To Guides"
-weight: 6
-date: 2017-01-05
+weight: 3
 description: >
   How to use or contribute to the project.
 ---

--- a/content/en/how-to-guides/configuration-management/_index.adoc
+++ b/content/en/how-to-guides/configuration-management/_index.adoc
@@ -11,50 +11,5 @@ description: >
 These guidelines assume that you're familiar with the GitHub workflow.
 {{% /pageinfo %}}
 
-We use a https://www.writethedocs.org/videos/portland/2019/lessons-learned-in-a-year-of-docs-driven-development-jessica-parsons/[docs-driven development] approach, using the GitHub workflow, to facilitate configuration management for Project Tetra. The documentation for this project is maintained in the https://github.com/tetrabiodistributed/project-tetra-docs[Project Tetra docs repo] with the project source code maintained in the https://github.com/helpfulengineering/project-tetra[Project Tetra repo].
+The following pages are a work-in-progress and intended for internal use by the Project Tetra team.
 
-== How to make changes to a design
-
-. Create a new working branch, or checkout an existing branch, in the https://github.com/tetrabiodistributed/project-tetra-docs[Project Tetra docs repo]. The branch name should describe the feature or component to be changed or implemented, e.g., `tricoder-with-touchscreen`.
-. Write or update the appropriate documentation files (i.e., link:../../tutorials[Tutorials], link:../../how-to-guides[How-To Guides], link:../../explanations[Explanations], and/or link:../../references[References]) relevant to the design changes to be made. (See <<#_how_to_write_good_documentation, How to write good documentation>>)
-. Commit the documentation changes to your working branch in the https://github.com/tetrabiodistributed/project-tetra-docs[Project Tetra docs repo].
-. Create a new working branch, or checkout an existing branch, in the https://github.com/helpfulengineering/project-tetra[Project Tetra repo]. The branch name should describe the feature or component to be changed or implemented, e.g., `tricoder-with-touchscreen`.
-. Implement the design changes in the appropriate design files (e.g., STEP files, drawings, STL's, and/or code). Simultaneously, update the documentation as need be in your working branch on the https://github.com/tetrabiodistributed/project-tetra-docs[Project Tetra docs repo].
-. Once satisfied with the design changes, update the P/N Registry and CHANGELOG. (See <<_how_to_document_a_part_number_release_hardware, How to document a part number release>> and <<_how_to_document_a_version_release_software, How to document a version release>>)
-. Commit the design changes to your working branch in the https://github.com/helpfulengineering/project-tetra[Project Tetra repo].
-. Create a pull request for your working branches in the https://github.com/tetrabiodistributed/project-tetra-docs[Project Tetra docs repo] and https://github.com/helpfulengineering/project-tetra[Project Tetra repo] to be merged into their respective main branch.
-
-== How to write good documentation
-
-There are four types of documentation: https://documentation.divio.com/tutorials[Tutorials], https://documentation.divio.com/how-to-guides/[How-To Guides], https://documentation.divio.com/reference/[References], and https://documentation.divio.com/explanation/#[Explanations].
-Consult the https://documentation.divio.com/[The Documentation System] for:
-
-* https://documentation.divio.com/tutorials/#how-to-write-good-tutorials[How to write good tutorials]
-* https://documentation.divio.com/how-to-guides/#how-to-write-good-how-to-guides[How to write good how-to guides]
-* https://documentation.divio.com/reference/#how-to-write-good-reference-guides[How to write good reference guides]
-* https://documentation.divio.com/explanation/#how-to-write-good-explanation[How to write good explanation]
-
-== How to document a part number release (hardware)
-
-Changes to a part number (P/N) should be made in the P/N Registry file, located in the root directory of the https://github.com/helpfulengineering/project-tetra[Project Tetra repo]. Part numbers should adopt the following naming convention: 
-
-  A-TET-ZZZZZZ-R = Assembly 
-      ZZZZZZ-R is Assembly Number & Revision
-  P-TET-ZZZZZZ-R = Part
-      ZZZZZZ-R is Part Number & Revision
-  M-YYY-ZZZZZ = Buy Part, M = Manufacturer, YYY = manufacturer code (ex, UNI = Unistrut)
-      ZZZZZ = Manufacturer part number
-  V-XXX-ZZZZZ = OTS part, V = Vendor, XXX = vendor code (ex, MCM = McMaster-Carr)
-      ZZZZ = Vendor part number
-
-Note: In the event there is a design change to an interface used in an existing part, it is recommended to designate an entirely new part number, as opposed to bumping its revision number.
-
-== How to document a version release (software)
-
-Changes to a software version (i.e., a software release) should be reflected in the CHANGELOG file, located in the root directory in the https://github.com/helpfulengineering/project-tetra[Project Tetra repo]. Software releases should also be https://help.github.com/en/github/administering-a-repository/managing-releases-in-a-repository[tagged] and follow the https://semver.org/[semantic versioning] system. 
-
-== Useful resources
-
-* https://www.docsy.dev/docs/[Docsy user guide]: All about Docsy, including how it manages navigation, look and feel, and multi-language support.
-* https://gohugo.io/documentation/[Hugo documentation]: Comprehensive reference for Hugo.
-* https://guides.github.com/activities/hello-world/[Github Hello World!]: A basic introduction to GitHub concepts and workflow.

--- a/content/en/how-to-guides/configuration-management/change_management.adoc
+++ b/content/en/how-to-guides/configuration-management/change_management.adoc
@@ -1,0 +1,62 @@
+
+---
+title: "Change Management"
+linkTitle: "Change Management"
+weight: 20
+description: >
+  Change Management Process for Project Tetra
+---
+
+{{% pageinfo %}}
+These guidelines assume that you're familiar with the GitHub workflow.
+{{% /pageinfo %}}
+
+== How to use the kanban board ==
+
+. Assign yourself to a new or existing card or issue in the https://github.com/orgs/tetrabiodistributed/projects/1[Project Tetra - kanban board]. Consult the GitHub project admin for access, if needed.
+  * Documentation related issues should be created in the https://github.com/tetrabiodistributed/project-tetra-docs/issues[Project Tetra docs issues] and added to the https://github.com/orgs/tetrabiodistributed/projects/1[Project Tetra - kanban board].
+
+  * Source code related issues should be created in the https://github.com/tetrabiodistributed/project-tetra/issues[Project Tetra issues] and added to the https://github.com/orgs/tetrabiodistributed/projects/1[Project Tetra - kanban board].
+
+  * Non-documentation or source code related issues should be added as a card to the https://github.com/orgs/tetrabiodistributed/projects/1[Project Tetra - kanban board].
+
+. Record relevant discussions in the comment section of the GitHub issues.
+
+== How to make documentation changes ==
+
+. Create a new branch, or checkout an existing branch, in the https://github.com/tetrabiodistributed/project-tetra-docs[Project Tetra docs repo]. The branch name should describe the changes to be made, followed by its associated issue number, e.g., `add-tricoder-with-touchscreen-docs-1701`. If no such issue exists, <<_creating_an_issue, create a new issue>>.
+
+. Write or update the appropriate documentation page relevant to the design changes to be made in your working branch.  All documentation should be nested under link:../../tutorials[Tutorials], link:../../how-to-guides[How-To Guides], link:../../explanations[Explanations], and/or link:../../references[References]. (See <<#_how_to_write_good_documentation, How to write good documentation>>)
+
+. Commit your changes and create a pull request (PR). Prepend the pull request title with the keyword for closing an issue, followed by the issue number, then issue description, e.g., `Closes #1701: add tricorder with touchscreen docs`. If the pull request closes multiple issues, simply reference each issue prepended with a closing keyword. (See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords[closing issues using keywords].
+
+. If you're not yet ready for a review, mark the PR as _Draft_ to indicate it's a work in progress. Continue updating your doc and pushing your changes until you're happy with the content.
+
+. When you're ready for a review, mark the PR as _Ready for review_.
+
+== How to make design changes ==
+
+Design changes include changes to CAD, STL, Drawings, or software.
+
+. Update the documentation to reflect the design changes to be made. (See <<_how_to_make_documentation_changes, How to make documentation changes>>)
+
+. Create a new working branch, or checkout an existing branch, in the https://github.com/tetrabiodistributed/project-tetra[Project Tetra repo]. The branch name should describe the change to be made, followed by its associated issue number, e.g., `add-tricoder-with-touchscreen-1031`. If no such issue exists, create a new issue in the https://github.com/tetrabiodistributed/project-tetra/issues[Project Tetra issues].
++
+Note: Part number revisions and version releases should accompany a design change where appropriate. (See link:../version_control/[Version Control])
+
+. Commit your changes and create a pull request (PR). Prepend the pull request title with the keyword for closing an issue, followed by the issue number, then issue description, e.g., `Closes #1031: add tricorder with touchscreen`. If the pull request closes multiple issues, simply reference each issue prepended with a closing keyword. (See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords[closing issues using keywords].
+
+. If you're not yet ready for a review, mark the PR as _Draft_ to indicate it's a work in progress. Continue updating your doc and pushing your changes until you're happy with the content.
+
+. When you're ready for a review, mark the PR as _Ready for review_.
+
+== Creating an issue
+
+If you've found a problem in the docs, but you're not sure how to fix it yourself, please create an issue in the https://github.com/tetrabiodistributed/project-tetra-docs/issues[Project Tetra docs repo]. You can also create an issue about a specific page by clicking the *Create documentation issue* button in the top right hand corner of the page.
+
+== Useful resources ==
+
+* https://www.docsy.dev/docs/[Docsy user guide]: All about Docsy, including how it manages navigation, look and feel, and multi-language support.
+* https://gohugo.io/documentation/[Hugo documentation]: Comprehensive reference for Hugo.
+* https://guides.github.com/activities/hello-world/[Github Hello World!]: A basic introduction to GitHub concepts and workflow.
+

--- a/content/en/how-to-guides/configuration-management/documentation.adoc
+++ b/content/en/how-to-guides/configuration-management/documentation.adoc
@@ -1,0 +1,21 @@
+
+---
+title: "Writing Documentation"
+linkTitle: "Writing Documentation"
+weight: 10
+description: >
+  Documentation methodology & how to write good documentation
+---
+
+We use a https://www.writethedocs.org/guide/docs-as-code/[Docs as Code] and https://www.writethedocs.org/videos/portland/2019/lessons-learned-in-a-year-of-docs-driven-development-jessica-parsons/[Docs-Driven Development] (i.e., __Document first, then implement what you documented__) approach, using the GitHub workflow, to facilitate documentation for Project Tetra. The documentation for this project is maintained in the https://github.com/tetrabiodistributed/project-tetra-docs[Project Tetra docs repo] with the project source code maintained in the https://github.com/tetrabiodistributed/project-tetra[Project Tetra repo].
+
+== How to write good documentation ==
+
+There are four types of documentation: https://documentation.divio.com/tutorials[Tutorials], https://documentation.divio.com/how-to-guides/[How-To Guides], https://documentation.divio.com/reference/[References], and https://documentation.divio.com/explanation/#[Explanations].
+Consult the https://documentation.divio.com/[The Documentation System] for:
+
+* https://documentation.divio.com/tutorials/#how-to-write-good-tutorials[How to write good tutorials]
+* https://documentation.divio.com/how-to-guides/#how-to-write-good-how-to-guides[How to write good how-to guides]
+* https://documentation.divio.com/reference/#how-to-write-good-reference-guides[How to write good reference guides]
+* https://documentation.divio.com/explanation/#how-to-write-good-explanation[How to write good explanation]
+

--- a/content/en/how-to-guides/configuration-management/version_control.adoc
+++ b/content/en/how-to-guides/configuration-management/version_control.adoc
@@ -1,0 +1,28 @@
+
+---
+title: "Version Control"
+linkTitle: "Version Control"
+weight: 30
+description: >
+  Version control guidelines
+---
+
+== How to document a part number release ==
+
+Part numbers for CAD, STL, & drawings should adopt the following naming convention: 
+
+  A-TET-ZZZZZZ-R = Assembly 
+      ZZZZZZ-R is Assembly Number & Revision
+  P-TET-ZZZZZZ-R = Part
+      ZZZZZZ-R is Part Number & Revision
+  M-YYY-ZZZZZ = Buy Part, M = Manufacturer, YYY = manufacturer code (ex, UNI = Unistrut)
+      ZZZZZ = Manufacturer part number
+  V-XXX-ZZZZZ = OTS part, V = Vendor, XXX = vendor code (ex, MCM = McMaster-Carr)
+      ZZZZ = Vendor part number
+
+Note: In the event there is a design change to an interface used in an existing part, it is recommended to designate an entirely new part number, as opposed to bumping its revision number.
+
+== How to document a version release ==
+
+Changes to a software version (i.e., a software release) should be reflected in the CHANGELOG file, located in the root directory in the https://github.com/tetrabiodistributed/project-tetra[Project Tetra repo]. Software releases should also be https://help.github.com/en/github/administering-a-repository/managing-releases-in-a-repository[tagged] and follow the https://semver.org/[semantic versioning] system. 
+

--- a/content/en/how-to-guides/contribution-guidelines/_index.adoc
+++ b/content/en/how-to-guides/contribution-guidelines/_index.adoc
@@ -1,10 +1,10 @@
 
 ---
-title: "Contribution Guidelines"
-linkTitle: "Contribution Guidelines"
+title: "Contributing to Documentation"
+linkTitle: "Contributing to Documentation"
 weight: 10
 description: >
-  How to contribute to the docs
+  How to contribute to the Project Tetra docs
 ---
 
 {{% pageinfo %}}
@@ -30,13 +30,10 @@ Consult https://help.github.com/articles/about-pull-requests/[GitHub Help] for m
 Here's a quick guide to updating the site:
 
 . Fork the https://github.com/tetrabiodistributed/project-tetra-docs[Project Tetra docs repo] on GitHub.
-. Make your changes and create a pull request (PR).
-. If you're not yet ready for a review, add "WIP" to the PR name to indicate
-  it's a work in progress.
-. Continue updating your doc and pushing your changes until you're happy with
-  the content.
-. When you're ready for a review, add a comment to the PR, and remove any
-  "WIP" markers.
+. Create a new branch, or checkout an existing branch. The branch name should describe the changes to be made, followed by its associated issue number, e.g., `add-tricoder-with-touchscreen-docs-1701`. If no such issue exists, <<_creating_an_issue, create a new issue>>.
+. Commit your changes and create a pull request (PR).
+. If you're not yet ready for a review, mark the PR as _Draft_ to indicate it's a work in progress. Continue updating your doc and pushing your changes until you're happy with the content.
+. When you're ready for a review, mark the PR as _Ready for review_.
 
 == Updating a single page
 
@@ -75,7 +72,7 @@ Note: If you accidentally cloned without using `--recurse-submodules`, you can r
 
 == Creating an issue
 
-If you've found a problem in the docs, but you're not sure how to fix it yourself, please create an issue in the https://github.com/tetrabiodistributed/project-tetra-docs/issues[Project Tetra docs repo]. You can also create an issue about a specific page by clicking the *Create Issue* button in the top right hand corner of the page.
+If you've found a problem in the docs, but you're not sure how to fix it yourself, please create an issue in the https://github.com/tetrabiodistributed/project-tetra-docs/issues[Project Tetra docs repo]. You can also create an issue about a specific page by clicking the *Create documentation issue* button in the top right hand corner of the page.
 
 == Useful resources
 

--- a/content/en/references/_index.adoc
+++ b/content/en/references/_index.adoc
@@ -2,7 +2,7 @@
 ---
 title: "References"
 linkTitle: "References"
-weight: 9
+weight: 4
 description: >
   Technical documents relevant to the project.
 ---

--- a/content/en/tutorials/_index.adoc
+++ b/content/en/tutorials/_index.adoc
@@ -2,8 +2,7 @@
 ---
 title: "Tutorials"
 linkTitle: "Tutorials"
-weight: 8
-date: 2017-01-04
+weight: 2
 description: >
   Assembly, build, and testing instructions through end-to-end examples.
 ---


### PR DESCRIPTION
- divide Configuration Management into 3 sub-pages: "Writing Documentation", "Change Management", & "Version Control"
- rename "Contribution guidelines" to "Contributing to Documentation"
- and refine verbiage in "How to make documentation changes" and "How to make design changes"
  - update instructions on branch naming convention to include issue number
  - add notes for closing one or multiple issues in a PR
- fix incorrect link from helpfulengineering to tetrabiodistributed in 3 files
- add section on how to use the kanban board
- add note that Configuration Management pages are a work-in-progress & intended for internal use.
- update project_repo to github.com/tetrabiodistributed/project-tetra in config.toml
- readjust weights, explanations: 1, tutorials: 2, how-to-guides: 3, references: 4