### PR TITLE
Closes #4

### DIFF
--- a/content/en/references/_index.adoc
+++ b/content/en/references/_index.adoc
@@ -6,5 +6,3 @@ weight: 4
 description: >
   Technical documents relevant to the project.
 ---
-
-link:ibd-system-electronic-sensing-system-dataflow.adoc[Sensing System UML Diagram]

--- a/content/en/references/_index.adoc
+++ b/content/en/references/_index.adoc
@@ -7,8 +7,4 @@ description: >
   Technical documents relevant to the project.
 ---
 
-* https://docs.google.com/document/d/1WbaJ5lhCMrui6hDj-EqaMEB5Ymmw-CQgvQznhYMCw9w/edit?usp=sharing[Project Proposal]
-* https://docs.google.com/document/d/164DD9j-OUmsBKB3FELcanB-5L1GkFy0qX10EiUfEtjM/edit[Testing Questions]
-* https://docs.google.com/spreadsheets/d/1FWTYRxglWDqIK_xI6HlBGKUegICQRsXe5NHCJTlTlHs/edit?usp=sharing[Printing Queue]
-* https://docs.google.com/presentation/d/1UeSRyUB0dAOZZecX4TGh40GkVtGADlXzBOwVFjPqIFE/edit#slide=id.g7f621674bc_0_63[System Concept Diagram]
-* link:circuit_schematic.adoc[Circuit Schematic UML Diagram]
+link:ibd-system-electronic-sensing-system-dataflow.adoc[Sensing System UML Diagram]

--- a/content/en/references/hardware_requirements.adoc
+++ b/content/en/references/hardware_requirements.adoc
@@ -4,7 +4,7 @@ title: "Hardware Requirements Outline"
 linkTitle: "Hardware Requirements Outline"
 weight: 1
 description: >
-  Summary of hardware design requirements for project tetra.
+  Summary of hardware design requirements for Project Tetra.
 ---
 
 == Section formatting

--- a/content/en/references/ibd-system-electronic-sensing-system-dataflow.adoc
+++ b/content/en/references/ibd-system-electronic-sensing-system-dataflow.adoc
@@ -3,10 +3,10 @@ title: "Electronic sensing system"
 linkTitle: "Electronic sensing system"
 weight: 1
 description: >
-  Circuit schematic for electronic sensing system
+  UML diagram of electronic sensing system
 ---
 
-[plantuml, circuit_schematic, svg]
+[plantuml, ibd-system-electronic-sensing-system-dataflow, svg]
 ....
 include::system_model/ibd-system-electronic-sensing-system-dataflow.puml[]
 ....

--- a/content/en/references/ibd-system-electronic-sensing-system-dataflow.adoc
+++ b/content/en/references/ibd-system-electronic-sensing-system-dataflow.adoc
@@ -1,9 +1,9 @@
 ---
-title: "Electronic sensing system"
-linkTitle: "Electronic sensing system"
+title: "Sensing System UML Diagram"
+linkTitle: "Sensing System UML Diagram"
 weight: 1
 description: >
-  UML diagram of electronic sensing system
+  UML diagram of Project Tetra's electronic sensing system.
 ---
 
 [plantuml, ibd-system-electronic-sensing-system-dataflow, svg]

--- a/content/en/references/ibd-system-electronic-sensing-system-dataflow.adoc
+++ b/content/en/references/ibd-system-electronic-sensing-system-dataflow.adoc
@@ -3,7 +3,7 @@ title: "Sensing System UML Diagram"
 linkTitle: "Sensing System UML Diagram"
 weight: 1
 description: >
-  UML diagram of Project Tetra's electronic sensing system.
+  UML diagInterface control document for electronic sensing system.
 ---
 
 [plantuml, ibd-system-electronic-sensing-system-dataflow, svg]

--- a/content/en/references/ibd-system-ventilator-splitter-assembly-airflow.adoc
+++ b/content/en/references/ibd-system-ventilator-splitter-assembly-airflow.adoc
@@ -1,0 +1,12 @@
+---
+title: "Splitter Assembly UML Diagram"
+linkTitle: "Splitter Assembly UML Diagram"
+weight: 1
+description: >
+  UML diagram of the Project Tetra splitter assembly.
+---
+
+[plantuml, ibd-system-ventilator-splitter-assembly-airflow, svg]
+....
+include::system_model/ibd-system-ventilator-splitter-assembly-airflow.puml[]
+....

--- a/content/en/references/ibd-system-ventilator-splitter-assembly-airflow.adoc
+++ b/content/en/references/ibd-system-ventilator-splitter-assembly-airflow.adoc
@@ -3,7 +3,7 @@ title: "Splitter Assembly UML Diagram"
 linkTitle: "Splitter Assembly UML Diagram"
 weight: 1
 description: >
-  UML diagram of the Project Tetra splitter assembly.
+  Interface control document for ventilator splitter assembly.
 ---
 
 [plantuml, ibd-system-ventilator-splitter-assembly-airflow, svg]


### PR DESCRIPTION
Closes #4 

In addition to removing the Google Drive links from the references, this pull request includes several minor changes:
- Removing the bullet points from references, which caused links to appear twice on the page
- Renaming circuit_schematic.adoc to ibd-system-electronic-sensing-system-dataflow.adoc, matching the diagram's naming structure.
- Links added to the UML diagram of the splitter assembly, as well as @Burhan-Q 's hardware requirement's list
-Minor capitalization/ description changes