### PR TITLE
add link to GoFundMe campaign

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+repo:     tetrabiodistributed/project-tetra-docs
+
+github:   tetrabiodistributed
+custom:   "gofundme.url"

--- a/config.toml
+++ b/config.toml
@@ -55,6 +55,11 @@ anchor = "smart"
     name = "Slack"
     weight = 50
     url = "https://app.slack.com/client/TUTSYURT3/C0103QJMA84"
+[[menu.main]]
+    name = "Donate"
+    weight = 50
+    url = "https://www.gofundme.com/"
+    # /\ Placeholder URL to update later
 
 [services]
 [services.googleAnalytics]


### PR DESCRIPTION
Closes #32 

Not ready to be pulled, as the GFM isn't set up yet. Making the PR now to log that everything else besides including the actual link is done.

-Adds .github/FUNDING.yml, which should enable a donation button on the project-tetra-docs repo
-Adds a link to the GFM in the header