### PR TITLE
update repo name to tetra in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,29 +1,29 @@
 = Project Tetra Docs
 
-This repository contains the content and source code for generating the https://tetrabiodistributed.github.io/project-tetra-docs[Project Tetra Docs] site.
+This repository contains the content and source code for generating the https://tetrabiodistributed.github.io/tetra[Project Tetra Docs] site.
 
-See https://tetrabiodistributed.github.io/project-tetra-docs/explanations/documentation-overview/[Documentation Overview].
+See https://tetrabiodistributed.github.io/tetra/explanations/documentation-overview/[Documentation Overview].
 
 == Running the website locally
 
 You can run your own Hugo server using docker to preview the site locally:
 
 . Install https://www.docker.com/[docker].
-. Clone the https://github.com/tetrabiodistributed/project-tetra-docs[Project Tetra docs repo]. Don't forget to use `--recurse-submodules` or you won't pull down some of the code you need to generate a working site.
+. Clone the https://github.com/tetrabiodistributed/tetra[Project Tetra docs repo]. Don't forget to use `--recurse-submodules` or you won't pull down some of the code you need to generate a working site.
 +
 [source,bash]
 ----
-git clone --recurse-submodules https://github.com/tetrabiodistributed/project-tetra-docs.git
-cd project-tetra-docs
+git clone --recurse-submodules https://github.com/tetrabiodistributed/tetra.git
+cd tetra
 ----
 Note: If you accidentally cloned without using `--recurse-submodules`, you can run `git submodule update --init --recursive` to pull down submodules needed to generate a working site.
-. Run the `build.sh` script in the site root directory (Note: Linux users may need to prepend this command `sudo`). This will build a docker image, as well as install node modules, needed to locally run the `project-tetra-docs` Hugo webserver. Once the image is built and stored on your machine, you do not need to rerun this step. You can view all locally installed images by running `docker images`.
+. Run the `build.sh` script in the site root directory (Note: Linux users may need to prepend this command `sudo`). This will build a docker image, as well as install node modules, needed to locally run the `tetra` Hugo webserver. Once the image is built and stored on your machine, you do not need to rerun this step. You can view all locally installed images by running `docker images`.
 +
 [source,bash]
 ----
 ./build.sh
 ----
-. Run the `serve.sh` script in the site root directory (Note: Linux users may need to prepend this command `sudo`). By default, your site will be available at `+http://localhost:1313/project-tetra-docs+`.
+. Run the `serve.sh` script in the site root directory (Note: Linux users may need to prepend this command `sudo`). By default, your site will be available at `+http://localhost:1313/tetra+`.
 +
 [source,bash]
 ----


### PR DESCRIPTION
project-tetra-docs changed to tetra in README

closes #119 